### PR TITLE
26 sort options

### DIFF
--- a/client/src/components/RatingsReviews/RatingsReviews.jsx
+++ b/client/src/components/RatingsReviews/RatingsReviews.jsx
@@ -11,6 +11,7 @@ class RatingsReviews extends React.Component {
       displayedReviews: [],
       numReviews: 0,
       numDisplayed: 0,
+      sortOption: 'relevance',
     };
 
     this.handleMoreReviews = this.handleMoreReviews.bind(this);
@@ -50,7 +51,7 @@ class RatingsReviews extends React.Component {
   render() {
     const { axiosConfig, productId } = this.props;
     const {
-      reviews, displayedReviews, numReviews, numDisplayed,
+      reviews, displayedReviews, numReviews, numDisplayed, sortOption
     } = this.state;
     return (
       <div className={RatingsReviewsCSS.ratings_section}>
@@ -65,7 +66,9 @@ class RatingsReviews extends React.Component {
             <p>Product Breakdown</p>
           </div>
           <div className={RatingsReviewsCSS.sort_options}>
-            <p>Sort Options</p>
+            <div>
+              {`${numReviews} reviews, ordered by ${sortOption}`}
+            </div>
           </div>
           <div className={RatingsReviewsCSS.reviews_list}>
             <ReviewsList

--- a/client/src/components/RatingsReviews/RatingsReviews.jsx
+++ b/client/src/components/RatingsReviews/RatingsReviews.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import RatingsReviewsCSS from './RatingsReviews.module.css';
 import ReviewsList from './ReviewsList.jsx';
 import MoreReviews from './MoreReviews.jsx';
+import SortOptions from './SortOptions.jsx';
 
 class RatingsReviews extends React.Component {
   constructor(props) {
@@ -11,16 +12,16 @@ class RatingsReviews extends React.Component {
       displayedReviews: [],
       numReviews: 0,
       numDisplayed: 0,
-      sortOption: 'relevance',
+      sortOption: 'relevant', // newest, helpful, relevant
     };
 
     this.handleMoreReviews = this.handleMoreReviews.bind(this);
+    this.handleSort = this.handleSort.bind(this);
   }
 
   componentDidMount() {
-    // GET reviews
     const { productId, axiosConfig } = this.props;
-    const productURL = `/reviews/?product_id=${productId}`;
+    const productURL = `/reviews/?sort=relevant&product_id=${productId}&count=1000`;
 
     axiosConfig.get(productURL)
       .then((response) => {
@@ -48,10 +49,34 @@ class RatingsReviews extends React.Component {
     });
   }
 
+  handleSort(event) {
+    console.log(event.target.value);
+    const { productId, axiosConfig } = this.props;
+    const sortOption = event.target.value;
+    console.log(sortOption);
+    const productURL = `/reviews/?sort=${sortOption}&product_id=${productId}&count=1000`;
+
+    axiosConfig.get(productURL)
+      .then((response) => {
+        const reviews = response.data.results;
+        const displayedReviews = response.data.results.slice(0, 2);
+        this.setState({
+          reviews,
+          displayedReviews,
+          numReviews: reviews.length,
+          numDisplayed: displayedReviews.length,
+          sortOption,
+        });
+      })
+      .catch((error) => {
+        console.log(error);
+      });
+  }
+
   render() {
     const { axiosConfig, productId } = this.props;
     const {
-      reviews, displayedReviews, numReviews, numDisplayed, sortOption
+      reviews, displayedReviews, numReviews, numDisplayed,
     } = this.state;
     return (
       <div className={RatingsReviewsCSS.ratings_section}>
@@ -66,9 +91,10 @@ class RatingsReviews extends React.Component {
             <p>Product Breakdown</p>
           </div>
           <div className={RatingsReviewsCSS.sort_options}>
-            <div>
-              {`${numReviews} reviews, ordered by ${sortOption}`}
-            </div>
+            <SortOptions
+              numReviews={numReviews}
+              handleSort={this.handleSort}
+            />
           </div>
           <div className={RatingsReviewsCSS.reviews_list}>
             <ReviewsList

--- a/client/src/components/RatingsReviews/RatingsReviews.module.css
+++ b/client/src/components/RatingsReviews/RatingsReviews.module.css
@@ -52,6 +52,7 @@
   grid-row-start: 2;
   grid-column: 2/4;
   border: 1px solid black;
+  font-weight: bold;
 }
 
 

--- a/client/src/components/RatingsReviews/SortOptions.jsx
+++ b/client/src/components/RatingsReviews/SortOptions.jsx
@@ -1,0 +1,24 @@
+import React from 'react';
+
+class SortOptions extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {};
+  }
+
+  render() {
+    const { numReviews, handleSort } = this.props;
+    return (
+      <div>
+        {`${numReviews} reviews, ordered by `}
+        <select onChange={handleSort}>
+          <option selected value="relevant">Relevance</option>
+          <option value="helpful">Helpfulness</option>
+          <option value="newest">Newest</option>
+        </select>
+      </div>
+    );
+  }
+}
+
+export default SortOptions;


### PR DESCRIPTION
**Trello:**
- https://trello.com/c/HKkjIesy/26-ratings-reviews-implement-sort-options-m

**Notes:**
- Atlier API forces count parameter, which defaults to 5, and then retrieves that number of reviews. For now, I've artificially set that to an arbitrarily large number (1000), which will be updated later.
- user can now sort reviews by helpfulness, relevance, and newest with relevant selected as the default

@allanviguilla @amberlyM @qzyan Can one of you pick up this PR and do a code review? Thanks!

In particular, looking for feedback on how I could refactor my code in `handleSort` and `componentDidMount` functions to not be so repetitive.

![image](https://user-images.githubusercontent.com/11972548/187732295-f9ff9168-a81a-40cc-a9a0-c47e51055c82.png)
