### PR TITLE
Fix currentIndex reset on style change

### DIFF
--- a/client/src/components/ProductOverview/Carousel/Carousel.jsx
+++ b/client/src/components/ProductOverview/Carousel/Carousel.jsx
@@ -11,7 +11,8 @@ export default function Carousel({ currentStyles }) {
     if (Object.keys(currentStyles).length !== 0) {
       setProductImages(currentStyles.photos);
       if (productImages.length !== 0) {
-        setCurrentImage(productImages[0].url);
+        setCurrentIndex(0);
+        setCurrentImage(productImages[currentIndex].url);
       }
     }
   }, [currentStyles, productImages]);


### PR DESCRIPTION
bug fix: currentIndex wasn't reseting on style change and arrows appear on the first index of new selected styles.

[Trello Ticket](https://trello.com/c/d1I2phjG/129-product-overview-fix-carousel-bug)

No visual changes.