### PR TITLE
37 rating breakdown

### DIFF
--- a/client/src/components/RatingsReviews/Breakdowns/RatingsBreakdown.jsx
+++ b/client/src/components/RatingsReviews/Breakdowns/RatingsBreakdown.jsx
@@ -17,14 +17,16 @@ export default class RatingsBreakdown extends React.Component {
 
     return (
       <div>
-        <div className={RatingsBreakdownCSS.star_rating}>
-          <p>
-            {`Average Rating: ${avgRating}`}
+        <div className={RatingsBreakdownCSS.top_box}>
+          <div>
+            <h1>{avgRating}</h1>
+          </div>
+          <div>
             ★★★★★
-          </p>
+          </div>
         </div>
         <div className={RatingsBreakdownCSS.recommmend_box}>
-          <p>{`Pct Recommend: ${pctRecommend}`}</p>
+          <p>{`${pctRecommend} of reviews recommend this product.`}</p>
         </div>
         <div className={RatingsBreakdownCSS.proportions_box}>
           <p>{`Rating Proportions: ${ratingProportions}`}</p>

--- a/client/src/components/RatingsReviews/Breakdowns/RatingsBreakdown.jsx
+++ b/client/src/components/RatingsReviews/Breakdowns/RatingsBreakdown.jsx
@@ -15,7 +15,7 @@ export default class RatingsBreakdown extends React.Component {
     const {
       avgRating, pctRecommend,
       ratingProportions, ratingCounts,
-      toggleFilter
+      toggleFilter, selectedRatings, handleSort,
     } = this.props;
 
     const ratings = Object.keys(ratingProportions).reverse();
@@ -33,6 +33,12 @@ export default class RatingsBreakdown extends React.Component {
         <div className={RatingsBreakdownCSS.grey_bar} />
       </div>
     ));
+
+    const filters = selectedRatings.map((num) => {
+      return (
+        <div>{`- ${num} Stars`}</div>
+      );
+    });
 
     return (
       <div className={RatingsBreakdownCSS.breakdown_container}>
@@ -62,6 +68,22 @@ export default class RatingsBreakdown extends React.Component {
         </div>
         <div>
           {ratingsBar}
+        </div>
+        <div>
+          {selectedRatings.length > 0 ? (
+            <>
+              Filters applied. Displaying reviews with:
+              {filters}
+              <input
+                type="submit"
+                value="Remove all filters"
+                onClick={() => handleSort(undefined, [])}
+              />
+            </>
+          )
+          :
+          (<></>)
+          }
         </div>
       </div>
     );

--- a/client/src/components/RatingsReviews/Breakdowns/RatingsBreakdown.jsx
+++ b/client/src/components/RatingsReviews/Breakdowns/RatingsBreakdown.jsx
@@ -15,12 +15,19 @@ export default class RatingsBreakdown extends React.Component {
     const {
       avgRating, pctRecommend,
       ratingProportions, ratingCounts,
+      toggleFilter
     } = this.props;
 
     const ratings = Object.keys(ratingProportions).reverse();
     const proportions = Object.values(ratingProportions).reverse();
     const ratingsBar = ratings.map((rating, index) => (
-      <div key={rating} className={RatingsBreakdownCSS.proportions_box}>
+      <div
+        key={rating}
+        className={RatingsBreakdownCSS.proportions_box}
+        onClick={(e) => toggleFilter(e, rating)}
+        role='button'
+        tabIndex="-1"
+        >
         {`${rating} Stars`}
         {/* {proportions[index]} */}
         <div className={RatingsBreakdownCSS.grey_bar} />

--- a/client/src/components/RatingsReviews/Breakdowns/RatingsBreakdown.jsx
+++ b/client/src/components/RatingsReviews/Breakdowns/RatingsBreakdown.jsx
@@ -6,8 +6,10 @@ export default class RatingsBreakdown extends React.Component {
     this.state = {
       avgRating: 0,
       pctRecommend: '',
+      ratingProportions: {},
+      ratingCounts: {},
     };
-    this.calculateAverageRating = this.calculateAverageRating.bind(this);
+    this.calculateRatings = this.calculateRatings.bind(this);
     this.calculatePercentRecommend = this.calculatePercentRecommend.bind(this);
   }
 
@@ -20,20 +22,26 @@ export default class RatingsBreakdown extends React.Component {
     }
   }
 
-  calculateAverageRating() {
+  calculateRatings() {
     const { metadata } = this.props;
     console.log("Metadata Ratings: ", metadata.ratings);
     const ratings = Object.keys(metadata.ratings);
     const counts = Object.values(metadata.ratings);
+    let ratingProportions = {};
     let denominator = 0;
     let numerator = 0;
     for (let i = 0; i < ratings.length; i++) {
       denominator += Number(counts[i]);
       numerator += Number(ratings[i]) * Number(counts[i]);
     }
+    for (let i = 0; i < ratings.length; i++) {
+      let key = ratings[i];
+      ratingProportions[key] = Number(counts[i]) / denominator;
+    }
     const avgRating = numerator / denominator;
     console.log("Average Rating: ", avgRating);
-    this.setState({ avgRating });
+    console.log("Average Rating: ", ratingProportions);
+    this.setState({ avgRating, ratingProportions, ratingCounts: ratings });
   }
 
   calculatePercentRecommend() {
@@ -47,10 +55,12 @@ export default class RatingsBreakdown extends React.Component {
     this.setState({ pctRecommend });
   }
 
+
   render() {
-    const { avgRating, pctRecommend } = this.state;
+    const { avgRating, pctRecommend, ratingProportions, ratingCounts } = this.state;
     return (
       <div>
+        <p>{avgRating}</p>
         <p>{`Average Rating: ${avgRating}`}</p>
         <p>{`Pct Recommend: ${pctRecommend}`}</p>
       </div>

--- a/client/src/components/RatingsReviews/Breakdowns/RatingsBreakdown.jsx
+++ b/client/src/components/RatingsReviews/Breakdowns/RatingsBreakdown.jsx
@@ -1,0 +1,59 @@
+import React from 'react';
+
+export default class RatingsBreakdown extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      avgRating: 0,
+      pctRecommend: '',
+    };
+    this.calculateAverageRating = this.calculateAverageRating.bind(this);
+    this.calculatePercentRecommend = this.calculatePercentRecommend.bind(this);
+  }
+
+  componentDidMount() {
+    const { metadata } = this.props;
+    console.log("Metadata: ", metadata);
+    if (Object.keys(metadata).length > 0) {
+      this.calculateAverageRating();
+      this.calculatePercentRecommend();
+    }
+  }
+
+  calculateAverageRating() {
+    const { metadata } = this.props;
+    console.log("Metadata Ratings: ", metadata.ratings);
+    const ratings = Object.keys(metadata.ratings);
+    const counts = Object.values(metadata.ratings);
+    let denominator = 0;
+    let numerator = 0;
+    for (let i = 0; i < ratings.length; i++) {
+      denominator += Number(counts[i]);
+      numerator += Number(ratings[i]) * Number(counts[i]);
+    }
+    const avgRating = numerator / denominator;
+    console.log("Average Rating: ", avgRating);
+    this.setState({ avgRating });
+  }
+
+  calculatePercentRecommend() {
+    const { metadata } = this.props;
+    console.log("Metadata Recommended: ", metadata.recommended);
+    const numerator = metadata.recommended.true;
+    const denominator = metadata.recommended.true + metadata.recommended.false;
+    const pctRecommend = numerator / denominator;
+    console.log("Percent Recommend: ", pctRecommend);
+
+    this.setState({ pctRecommend });
+  }
+
+  render() {
+    const { avgRating, pctRecommend } = this.state;
+    return (
+      <div>
+        <p>{`Average Rating: ${avgRating}`}</p>
+        <p>{`Pct Recommend: ${pctRecommend}`}</p>
+      </div>
+    );
+  }
+}

--- a/client/src/components/RatingsReviews/Breakdowns/RatingsBreakdown.jsx
+++ b/client/src/components/RatingsReviews/Breakdowns/RatingsBreakdown.jsx
@@ -1,68 +1,34 @@
 import React from 'react';
+import RatingsBreakdownCSS from './RatingsBreakdown.module.css';
 
 export default class RatingsBreakdown extends React.Component {
   constructor(props) {
     super(props);
-    this.state = {
-      avgRating: 0,
-      pctRecommend: '',
-      ratingProportions: {},
-      ratingCounts: {},
-    };
-    this.calculateRatings = this.calculateRatings.bind(this);
-    this.calculatePercentRecommend = this.calculatePercentRecommend.bind(this);
+    this.state = {};
   }
-
-  componentDidMount() {
-    const { metadata } = this.props;
-    console.log("Metadata: ", metadata);
-    if (Object.keys(metadata).length > 0) {
-      this.calculateAverageRating();
-      this.calculatePercentRecommend();
-    }
-  }
-
-  calculateRatings() {
-    const { metadata } = this.props;
-    console.log("Metadata Ratings: ", metadata.ratings);
-    const ratings = Object.keys(metadata.ratings);
-    const counts = Object.values(metadata.ratings);
-    let ratingProportions = {};
-    let denominator = 0;
-    let numerator = 0;
-    for (let i = 0; i < ratings.length; i++) {
-      denominator += Number(counts[i]);
-      numerator += Number(ratings[i]) * Number(counts[i]);
-    }
-    for (let i = 0; i < ratings.length; i++) {
-      let key = ratings[i];
-      ratingProportions[key] = Number(counts[i]) / denominator;
-    }
-    const avgRating = numerator / denominator;
-    console.log("Average Rating: ", avgRating);
-    console.log("Average Rating: ", ratingProportions);
-    this.setState({ avgRating, ratingProportions, ratingCounts: ratings });
-  }
-
-  calculatePercentRecommend() {
-    const { metadata } = this.props;
-    console.log("Metadata Recommended: ", metadata.recommended);
-    const numerator = metadata.recommended.true;
-    const denominator = metadata.recommended.true + metadata.recommended.false;
-    const pctRecommend = numerator / denominator;
-    console.log("Percent Recommend: ", pctRecommend);
-
-    this.setState({ pctRecommend });
-  }
-
 
   render() {
-    const { avgRating, pctRecommend, ratingProportions, ratingCounts } = this.state;
+    const {
+      avgRating, pctRecommend,
+      ratingProportions, ratingCounts,
+    } = this.props;
+
+    // const ratingsBar = ratingProportions.m
+
     return (
       <div>
-        <p>{avgRating}</p>
-        <p>{`Average Rating: ${avgRating}`}</p>
-        <p>{`Pct Recommend: ${pctRecommend}`}</p>
+        <div className={RatingsBreakdownCSS.star_rating}>
+          <p>
+            {`Average Rating: ${avgRating}`}
+            ★★★★★
+          </p>
+        </div>
+        <div className={RatingsBreakdownCSS.recommmend_box}>
+          <p>{`Pct Recommend: ${pctRecommend}`}</p>
+        </div>
+        <div className={RatingsBreakdownCSS.proportions_box}>
+          <p>{`Rating Proportions: ${ratingProportions}`}</p>
+        </div>
       </div>
     );
   }

--- a/client/src/components/RatingsReviews/Breakdowns/RatingsBreakdown.jsx
+++ b/client/src/components/RatingsReviews/Breakdowns/RatingsBreakdown.jsx
@@ -1,4 +1,8 @@
 import React from 'react';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faStar, faCirclePlus } from '@fortawesome/free-solid-svg-icons';
+import { faStar as faRegStar, faCircleXmark } from '@fortawesome/free-regular-svg-icons';
+
 import RatingsBreakdownCSS from './RatingsBreakdown.module.css';
 
 export default class RatingsBreakdown extends React.Component {
@@ -13,23 +17,44 @@ export default class RatingsBreakdown extends React.Component {
       ratingProportions, ratingCounts,
     } = this.props;
 
-    // const ratingsBar = ratingProportions.m
+    const ratings = Object.keys(ratingProportions).reverse();
+    const proportions = Object.values(ratingProportions).reverse();
+    const ratingsBar = ratings.map((rating, index) => (
+      <div key={rating} className={RatingsBreakdownCSS.proportions_box}>
+        {`${rating} Stars`}
+        {/* {proportions[index]} */}
+        <div className={RatingsBreakdownCSS.grey_bar} />
+      </div>
+    ));
 
     return (
-      <div>
+      <div className={RatingsBreakdownCSS.breakdown_container}>
         <div className={RatingsBreakdownCSS.top_box}>
           <div>
             <h1>{avgRating}</h1>
           </div>
-          <div>
-            ★★★★★
+          <div className={RatingsBreakdownCSS.rating}>
+            <div
+              className={RatingsBreakdownCSS.rating_overlay}
+              style={{ width: `${avgRating * 20}%` }}
+            />
+            {/* <div className={RatingsBreakdownCSS.star}>☆</div>
+              <div className={RatingsBreakdownCSS.star}>☆</div>
+              <div className={RatingsBreakdownCSS.star}>☆</div>
+              <div className={RatingsBreakdownCSS.star}>☆</div>
+              <div className={RatingsBreakdownCSS.star}>☆</div> */}
+            <FontAwesomeIcon icon={faStar} size="lg" className={RatingsBreakdownCSS.star} />
+            <FontAwesomeIcon icon={faStar} size="lg" className={RatingsBreakdownCSS.star} />
+            <FontAwesomeIcon icon={faStar} size="lg" className={RatingsBreakdownCSS.star} />
+            <FontAwesomeIcon icon={faStar} size="lg" className={RatingsBreakdownCSS.star} />
+            <FontAwesomeIcon icon={faStar} size="lg" className={RatingsBreakdownCSS.star} />
           </div>
         </div>
         <div className={RatingsBreakdownCSS.recommmend_box}>
           <p>{`${pctRecommend} of reviews recommend this product.`}</p>
         </div>
-        <div className={RatingsBreakdownCSS.proportions_box}>
-          <p>{`Rating Proportions: ${ratingProportions}`}</p>
+        <div>
+          {ratingsBar}
         </div>
       </div>
     );

--- a/client/src/components/RatingsReviews/Breakdowns/RatingsBreakdown.module.css
+++ b/client/src/components/RatingsReviews/Breakdowns/RatingsBreakdown.module.css
@@ -1,5 +1,12 @@
-.star_rating {
-  font-weight: bold;
+h1 {
+  margin: 0 0
+}
+
+.top_box {
+  display: flex;
+  gap: 1em;
+  flex-direction: row;
+  align-items: top;
 }
 
 .recommend_box {

--- a/client/src/components/RatingsReviews/Breakdowns/RatingsBreakdown.module.css
+++ b/client/src/components/RatingsReviews/Breakdowns/RatingsBreakdown.module.css
@@ -2,6 +2,10 @@ h1 {
   margin: 0 0
 }
 
+.breakdown_container {
+  padding: 0.5em 0.5em;
+}
+
 .top_box {
   display: flex;
   gap: 1em;
@@ -14,13 +18,64 @@ h1 {
 }
 
 .proportions_box {
-
+  display: flex;
+  flex-direction: row;
+  height: 1rem;
+  gap: 1em;
+  padding-bottom: 0.5em;
+  font-weight: bold;
 }
 
 .grey_bar {
-
+  border: 1px solid black;
+  background-color: darkgrey;
+  width: 60%;
+  height: 100%;
 }
 
-.green_bar {
-
+.rating {
+  position: relative;
+  background-color: red;
+  display: inline-flex;
+  justify-content: space-around;
 }
+
+.rating_overlay {
+  background-color: #0ABAB5;
+  opacity: 75%;
+  position: absolute;
+  left: 0;
+  top: 0;
+  height: 100%;
+  mix-blend-mode: color;
+}
+
+.star {
+  color: lightgray;
+  display: flex;
+  justify-content: left;
+  /* font-size: 28; */
+}
+
+/* .rating {
+  position: relative;
+  background-color: white;
+  display: inline-flex;
+  justify-content: space-around;
+}
+
+.rating-overlay {
+  background-color: #0ABAB5;
+  opacity: 75%;
+  position: absolute;
+  left: 0;
+  top: 0;
+  height: 100%;
+  mix-blend-mode: color;
+}
+
+.star {
+  color: lightgray;
+  display: flex;
+  justify-content: left;
+} */

--- a/client/src/components/RatingsReviews/Breakdowns/RatingsBreakdown.module.css
+++ b/client/src/components/RatingsReviews/Breakdowns/RatingsBreakdown.module.css
@@ -13,6 +13,8 @@ h1 {
   align-items: top;
 }
 
+
+
 .recommend_box {
   font-style: italic;
 }
@@ -24,6 +26,10 @@ h1 {
   gap: 1em;
   padding-bottom: 0.5em;
   font-weight: bold;
+}
+
+.proportions_box:hover {
+  background-color: grey;
 }
 
 .grey_bar {

--- a/client/src/components/RatingsReviews/Breakdowns/RatingsBreakdown.module.css
+++ b/client/src/components/RatingsReviews/Breakdowns/RatingsBreakdown.module.css
@@ -10,7 +10,7 @@ h1 {
   display: flex;
   gap: 1em;
   flex-direction: row;
-  align-items: top;
+  align-items: center;
 }
 
 
@@ -35,7 +35,7 @@ h1 {
 .grey_bar {
   border: 1px solid black;
   background-color: darkgrey;
-  width: 60%;
+  width: 70%;
   height: 100%;
 }
 

--- a/client/src/components/RatingsReviews/Breakdowns/RatingsBreakdown.module.css
+++ b/client/src/components/RatingsReviews/Breakdowns/RatingsBreakdown.module.css
@@ -1,0 +1,19 @@
+.star_rating {
+  font-weight: bold;
+}
+
+.recommend_box {
+  font-style: italic;
+}
+
+.proportions_box {
+
+}
+
+.grey_bar {
+
+}
+
+.green_bar {
+
+}

--- a/client/src/components/RatingsReviews/RatingsReviews.jsx
+++ b/client/src/components/RatingsReviews/RatingsReviews.jsx
@@ -187,7 +187,6 @@ class RatingsReviews extends React.Component {
             </span>
           </div>
           <div className={RatingsReviewsCSS.ratings_breakdown_sidebar}>
-            <p>Ratings Breakdown</p>
             <RatingsBreakdown
               productId={productId}
               // metadata={metadata}

--- a/client/src/components/RatingsReviews/RatingsReviews.jsx
+++ b/client/src/components/RatingsReviews/RatingsReviews.jsx
@@ -4,6 +4,7 @@ import ReviewsList from './ReviewsList.jsx';
 import MoreReviews from './MoreReviews.jsx';
 import SortOptions from './SortOptions.jsx';
 import NewReview from './NewReview.jsx';
+import RatingsBreakdown from './Breakdowns/RatingsBreakdown.jsx';
 
 class RatingsReviews extends React.Component {
   constructor(props) {
@@ -14,7 +15,7 @@ class RatingsReviews extends React.Component {
       displayedReviews: [],
       numReviews: 0,
       numDisplayed: 0,
-      sortOption: 'relevant', // newest, helpful, relevant
+      // sortOption: 'relevant', // newest, helpful, relevant
       metadata: {},
     };
 
@@ -119,10 +120,11 @@ class RatingsReviews extends React.Component {
 
   updateMetadata() {
     const { productId, axiosConfig } = this.props;
-    const metaURL = `https://app-hrsei-api.herokuapp.com/api/fec2/rfp/reviews/meta?product_id=${productId}`;
+    const metaURL = `/reviews/meta?product_id=${productId}`;
 
     axiosConfig.get(metaURL)
       .then((response) => {
+        console.log(response.data);
         this.setState({ metadata: response.data });
       })
       .catch((error) => {
@@ -133,7 +135,7 @@ class RatingsReviews extends React.Component {
   render() {
     const { axiosConfig, IMGBB_API_KEY, productId } = this.props;
     const {
-      reviews, displayedReviews, numReviews, numDisplayed, productName, metadata
+      reviews, displayedReviews, numReviews, numDisplayed, productName, metadata,
     } = this.state;
     return (
       <div className={RatingsReviewsCSS.ratings_section}>
@@ -147,6 +149,10 @@ class RatingsReviews extends React.Component {
           </div>
           <div className={RatingsReviewsCSS.ratings_breakdown_sidebar}>
             <p>Ratings Breakdown</p>
+            <RatingsBreakdown
+              productId={productId}
+              metadata={metadata}
+            />
           </div>
           <div className={RatingsReviewsCSS.product_breakdown_sidebar}>
             <p>Product Breakdown</p>

--- a/client/src/components/RatingsReviews/RatingsReviews.jsx
+++ b/client/src/components/RatingsReviews/RatingsReviews.jsx
@@ -1,4 +1,6 @@
 import React from 'react';
+import _ from 'underscore';
+
 import RatingsReviewsCSS from './RatingsReviews.module.css';
 import ReviewsList from './ReviewsList.jsx';
 import MoreReviews from './MoreReviews.jsx';
@@ -21,6 +23,7 @@ class RatingsReviews extends React.Component {
       pctRecommend: '',
       ratingProportions: {},
       ratingCounts: {},
+      selectedRatings: [1, 2, 3, 4, 5],
     };
 
     this.updateReviews = this.updateReviews.bind(this);
@@ -31,6 +34,7 @@ class RatingsReviews extends React.Component {
     this.handleSort = this.handleSort.bind(this);
     this.calculateRatings = this.calculateRatings.bind(this);
     this.calculatePercentRecommend = this.calculatePercentRecommend.bind(this);
+    this.toggleFilter = this.toggleFilter.bind(this);
   }
 
   componentDidMount() {
@@ -170,11 +174,36 @@ class RatingsReviews extends React.Component {
     this.setState({ pctRecommend: `${pctRecommend}%` });
   }
 
+  toggleFilter(event, rating) {
+    console.log(event);
+    console.log(rating);
+
+    let { selectedRatings, displayedReviews } = this.state;
+
+    rating = Number(rating);
+    if (!selectedRatings.includes(rating)) {
+      selectedRatings.push(rating);
+    } else if (selectedRatings.includes(rating)) {
+      selectedRatings = _.filter(selectedRatings, function(num) {return num !== rating} );
+    }
+    if (selectedRatings.length === 0) {
+      selectedRatings = [1, 2, 3, 4, 5];
+    }
+    this.setState({ selectedRatings });
+
+    const filteredDisplayedReviews = _.filter(displayedReviews, function(review) {
+      return selectedRatings.includes(review.rating)
+    });
+    console.log(selectedRatings);
+    console.log(filteredDisplayedReviews);
+    this.setState({ displayedReviews: filteredDisplayedReviews });
+  }
+
   render() {
     const { axiosConfig, IMGBB_API_KEY, productId } = this.props;
     const {
       reviews, displayedReviews, numReviews, numDisplayed, productName, metadata,
-      avgRating, pctRecommend, ratingProportions, ratingCounts,
+      avgRating, pctRecommend, ratingProportions, ratingCounts, selectedRatings,
     } = this.state;
     return (
       <div className={RatingsReviewsCSS.ratings_section}>
@@ -188,6 +217,7 @@ class RatingsReviews extends React.Component {
           </div>
           <div className={RatingsReviewsCSS.ratings_breakdown_sidebar}>
             <RatingsBreakdown
+              toggleFilter={this.toggleFilter}
               productId={productId}
               // metadata={metadata}
               avgRating={avgRating}

--- a/client/src/components/RatingsReviews/RatingsReviews.jsx
+++ b/client/src/components/RatingsReviews/RatingsReviews.jsx
@@ -17,7 +17,6 @@ class RatingsReviews extends React.Component {
       displayedReviews: [],
       numReviews: 0,
       numDisplayed: 0,
-      sortOption: 'relevant', // newest, helpful, relevant
       metadata: {},
       avgRating: 0,
       pctRecommend: '',
@@ -86,7 +85,6 @@ class RatingsReviews extends React.Component {
           displayedReviews,
           numReviews: reviews.length,
           numDisplayed: displayedReviews.length,
-          sortOption,
         });
       })
       .catch((error) => {

--- a/client/src/components/RatingsReviews/RatingsReviews.module.css
+++ b/client/src/components/RatingsReviews/RatingsReviews.module.css
@@ -22,6 +22,8 @@
 }
 
 .ratings_breakdown_sidebar {
+  display: flex;
+  flex-direction: column;
   background-color: red;
   grid-column: 1;
   grid-row: 2/4;

--- a/client/src/components/RatingsReviews/SortOptions.jsx
+++ b/client/src/components/RatingsReviews/SortOptions.jsx
@@ -10,7 +10,7 @@ class SortOptions extends React.Component {
     const { numReviews, handleSort } = this.props;
     return (
       <div>
-        {`${numReviews} reviews, ordered by `}
+        {`${numReviews} reviews, sorted by `}
         <select defaultValue="relevant" onChange={handleSort}>
           <option value="relevant">Relevance</option>
           <option value="helpful">Helpfulness</option>

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,8 @@
         "react-dom": "^18.2.0",
         "react-icons": "^4.4.0",
         "react-spring": "^9.0.0-rc.3",
-        "styled-components": "^5.3.5"
+        "styled-components": "^5.3.5",
+        "underscore": "^1.13.4"
       },
       "devDependencies": {
         "@babel/core": "^7.18.13",
@@ -18202,6 +18203,11 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/underscore": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.4.tgz",
+      "integrity": "sha512-BQFnUDuAQ4Yf/cYY5LNrK9NCJFKriaRbD9uR1fTeXnBeoa97W0i41qkZfGO9pSo8I5KzjAcSY2XYtdf0oKd7KQ=="
+    },
     "node_modules/unicode-canonical-property-names-ecmascript": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/unicode-canonical-property-names-ecmascript/-/unicode-canonical-property-names-ecmascript-2.0.0.tgz",
@@ -32988,6 +32994,11 @@
         "has-symbols": "^1.0.3",
         "which-boxed-primitive": "^1.0.2"
       }
+    },
+    "underscore": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.4.tgz",
+      "integrity": "sha512-BQFnUDuAQ4Yf/cYY5LNrK9NCJFKriaRbD9uR1fTeXnBeoa97W0i41qkZfGO9pSo8I5KzjAcSY2XYtdf0oKd7KQ=="
     },
     "unicode-canonical-property-names-ecmascript": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,8 @@
     "react-dom": "^18.2.0",
     "react-icons": "^4.4.0",
     "react-spring": "^9.0.0-rc.3",
-    "styled-components": "^5.3.5"
+    "styled-components": "^5.3.5",
+    "underscore": "^1.13.4"
   },
   "devDependencies": {
     "@babel/core": "^7.18.13",


### PR DESCRIPTION
**Trello:**
- https://trello.com/c/pHppaWtI/37-ratings-review-implement-rating-breakdown-1-3-m
- https://trello.com/c/swZnlqdR/35-ratings-reviews-implement-rating-breakdown-2-m

**Description:**
- creates design of Ratings Breakdown subwidget
- shows average star rating for the product as both a number (e.g. 4.1) and as a star rating shaded in
- displays % of reviews that recommend the product
- shows clickable grey bars for each star rating (i.e. 5 Stars, 4 Stars, etc.) that filter the displayed reviews

**Outstanding Issues (What this PR does not do AND what I need help with):**
- I attempted to adapt @qzyan's code for mine to properly shade the star ratings. I got it maybe 90% of the way there, but for some reason I'm shading an entire box instead of just the stars. Also, the stars are not shading to the nearest 0.25 stars.
![image](https://user-images.githubusercontent.com/11972548/188362254-91d3fdd1-2118-4753-be4a-e877a2190245.png)

- Grey bars should be green based on the proportion of total reviews that selected that star rating. The `state` with this data has been created and stored, but I have not attempted to style the CSS yet.
![image](https://user-images.githubusercontent.com/11972548/188362426-fedab45f-a2b2-4b82-a8dc-b77f0c654a65.png)
![image](https://user-images.githubusercontent.com/11972548/188362498-ebdb1fcc-cd64-478f-bfdd-7426bac4e06e.png)

**Screenshot:**
![image](https://user-images.githubusercontent.com/11972548/188361833-fcbac475-ccae-486f-b480-499b0f4c3be9.png)

**Screenshot (with filters applied): **
![image](https://user-images.githubusercontent.com/11972548/188362159-aa7a9837-2615-441c-b205-6f05cdce745c.png)
